### PR TITLE
Remove erroneous character

### DIFF
--- a/tasks/Build.cfc
+++ b/tasks/Build.cfc
@@ -247,4 +247,4 @@ component {
 		variables.exportsDir = variables.artifactsDir & "/#projectName#/#arguments.version#";
 		directoryCreate( variables.exportsDir, true, true );
 	}
-}e
+}


### PR DESCRIPTION
Remove unexpected character at the end of the file which appears to be a typo. This commit does not change functionality, it is a clean up only.