### PR TITLE
Fix FacebookProvider response parsing - event required for getRedirectUri( )

### DIFF
--- a/models/providers/FacebookProvider.cfc
+++ b/models/providers/FacebookProvider.cfc
@@ -56,7 +56,7 @@ component
 			var res = oAuthService.makeAccessTokenRequest(
 				getClientId(),
 				getClientSecret(),
-				getRedirectUri(),
+				getRedirectUri(event),
 				getAccessTokenEndpoint(),
 				event.getValue( "code" )
 			);


### PR DESCRIPTION
added event as required for getRedirectUri( )

# Description

Please include a summary of the changes and which issue(s) is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Please note that all PRs must have tests attached to them**

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Issues

All PRs must have an accompanied issue. Please make sure you created it and linked it here.

## Type of change

Please delete options that are not relevant.

- [ ] Bug Fix


## Checklist

