### PR TITLE
fix: remove duplicate variable name from BaseProvider.cfc

### DIFF
--- a/models/providers/BaseProvider.cfc
+++ b/models/providers/BaseProvider.cfc
@@ -9,8 +9,6 @@ component {
 			return variables.redirectURI;
 		}
 
-		var event = requestService.getContext();
-
 		return "#event.getHTMLBaseURL()#cbsso/auth/#variables.name.lcase()#";
 	}
 

--- a/models/providers/GoogleProvider.cfc
+++ b/models/providers/GoogleProvider.cfc
@@ -51,7 +51,7 @@ component
 			var res = oAuthService.makeAccessTokenRequest(
 				getClientId(),
 				getClientSecret(),
-				getRedirectUri(),
+				getRedirectUri( event ),
 				getAccessTokenEndpoint(),
 				event.getValue( "code" )
 			);

--- a/models/utility/SAMLParsingService.cfc
+++ b/models/utility/SAMLParsingService.cfc
@@ -81,7 +81,7 @@ component singleton {
 	private string function extractEmail( required xmlDoc ){
 		return xmlSearch(
 			xmlDoc,
-			"//Attribute[@Name='http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress']"
+			"//Attribute[@Name='http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name']"
 		)[ 1 ].xmlchildren[ 1 ].xmltext;
 	}
 


### PR DESCRIPTION
# Description
BaseProvider.cfc has function getRedirectUri with a required argument "event", but another variable is defined in that function with the same name. Removing the duplicate variable keeps the same functionality.

## Issues
1. BaseProvider.cfc - Duplicate variable name - same as defined in arguments
2. GoogleProvider.cfc - requests url from baseProvider.getRedirectUri, but without the required "event" argument
3. MicrosoftProvider.cfc - incorrect xml string to retrieve emailAddress

## Fix
1. removed the duplicate variable
2. added "event" as an argument
3. replaced "claims/emailAddress" with "claims/name"
